### PR TITLE
Render currently enabled services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 COLTE_FULL_VERSION=0.10.1
 COLTE_VERSION=0.9.12
 CONF_VERSION=0.9.13
-WEBGUI_VERSION=0.9.11
+WEBGUI_VERSION=0.9.12
 WEBADMIN_VERSION=0.9.1
 
 TARGET_DIR=./BUILD/
@@ -95,6 +95,7 @@ webgui: target
 		./package/webgui/colte-webgui.service=/etc/systemd/system/colte-webgui.service \
 		./package/webgui/webgui.env=/usr/local/etc/colte/webgui.env \
 		./package/webgui/pricing.json=/usr/local/etc/colte/pricing.json \
+		./package/webgui/services.json=/usr/local/etc/colte/services.json \
 		./package/webgui/transaction_log.txt=/var/log/colte/transaction_log.txt 
 
 webadmin: target

--- a/package/webgui/services.json
+++ b/package/webgui/services.json
@@ -1,0 +1,10 @@
+{
+    "Google": {
+        "enabled": false,
+        "url": "https://www.google.com"
+    },
+    "YouTube": {
+        "enabled": false,
+        "url": "http://www.youtube.com"
+    }
+}

--- a/package/webgui/services.json
+++ b/package/webgui/services.json
@@ -1,10 +1,10 @@
 {
-    "Google": {
-        "enabled": false,
-        "url": "https://www.google.com"
+    "Wikipedia": {
+        "enabled": true,
+        "url": "https://www.wikipedia.org/"
     },
-    "YouTube": {
+    "OpenStreetMaps": {
         "enabled": false,
-        "url": "http://www.youtube.com"
+        "url": "https://www.openstreetmap.org/"
     }
 }

--- a/webgui/app.js
+++ b/webgui/app.js
@@ -77,6 +77,12 @@ fs.appendFile(transaction_log, "", function(err) {
 var content = fs.readFileSync("pricing.json");
 module.exports.pricing = JSON.parse(content);
 
+// read JSON file with links to free local services (optional)
+if (process.env.ENABLED_SERVICES) {
+  var file = fs.readFileSync(process.env.ENABLED_SERVICES);
+  module.exports.services = JSON.parse(file);
+}
+
 // setup routes (i.e. a request for /home goes to /routes/home.js)
 fs.readdirSync('./routes').forEach(function(file) {
   if (file.substr(-3) == '.js') {

--- a/webgui/production.env
+++ b/webgui/production.env
@@ -6,3 +6,4 @@ PORT=7999
 NODE_ENV=development
 LOCALE=en
 TRANSACTION_LOG=/var/log/colte/transaction_log.txt
+ENABLED_SERVICES=/usr/local/etc/colte/services.json

--- a/webgui/production.env
+++ b/webgui/production.env
@@ -6,4 +6,6 @@ PORT=7999
 NODE_ENV=development
 LOCALE=en
 TRANSACTION_LOG=/var/log/colte/transaction_log.txt
-ENABLED_SERVICES=/usr/local/etc/colte/services.json
+ENABLED_SERVICES=""
+# If you would like to enable services, uncomment this!
+# ENABLED_SERVICES=/usr/local/etc/colte/services.json

--- a/webgui/routes/purchase.js
+++ b/webgui/routes/purchase.js
@@ -17,6 +17,7 @@ router.get('/', function(req, res, next) {
       balance: data[0].balance,
       admin: data[0].admin,
       pack: app.pricing.packages,
+      services: app.services,
     });
   });
 });

--- a/webgui/routes/services.js
+++ b/webgui/routes/services.js
@@ -3,6 +3,30 @@ var router = express.Router();
 var customer = require('../models/customer');
 var app = require('../app');
 
+/* Gets services currently enabled by admin, as specified in 
+/usr/local/etc/colte/services.json. Format of JSON file should be: 
+{
+  serviceName: {
+    enabled: boolean,
+    url: string
+  }, 
+  ...
+}*/
+function getEnabledServices(servicesObject) {
+  var array = [];
+
+  for (var service in servicesObject) {
+    if (servicesObject[service].enabled) {
+      array.push({
+        serviceName: service,
+        url: servicesObject[service].url
+      });
+    }
+  } 
+
+  return array;
+}
+
 router.get('/', function(req, res, next) {
 
   var ip = app.generateIP(req.ip);
@@ -14,10 +38,16 @@ router.get('/', function(req, res, next) {
     // raw_down_str = convertBytes(data[0].raw_down);
     // data_balance_str = convertBytes(data[0].data_balance);
 
+    var services = process.env.ENABLED_SERVICES === "" ? 
+        {} : JSON.parse(process.env.ENABLED_SERVICES);
+
+    var enabledServices = getEnabledServices(services);
+
     res.render('services', {
       translate: app.translate,
       title: app.translate("Home"),
       admin: data[0].admin,
+      services: enabledServices
       // raw_up_str: raw_up_str,
       // raw_down_str: raw_down_str,
       // balance: data[0].balance,

--- a/webgui/routes/services.js
+++ b/webgui/routes/services.js
@@ -1,17 +1,20 @@
+/* Local services should be listed and enabled in /usr/local/etc/colte/services.json. 
+  Format of JSON file should be: 
+  {
+    serviceName: {
+      enabled: boolean,
+      url: string
+    }, 
+    ...
+  }
+*/
+
 var express = require('express');
 var router = express.Router();
 var customer = require('../models/customer');
 var app = require('../app');
 
-/* Gets services currently enabled by admin, as specified in 
-/usr/local/etc/colte/services.json. Format of JSON file should be: 
-{
-  serviceName: {
-    enabled: boolean,
-    url: string
-  }, 
-  ...
-}*/
+/* Gets services currently enabled by admin */
 function getEnabledServices(servicesObject) {
   var array = [];
 

--- a/webgui/routes/services.js
+++ b/webgui/routes/services.js
@@ -41,10 +41,7 @@ router.get('/', function(req, res, next) {
     // raw_down_str = convertBytes(data[0].raw_down);
     // data_balance_str = convertBytes(data[0].data_balance);
 
-    var services = process.env.ENABLED_SERVICES === "" ? 
-        {} : JSON.parse(process.env.ENABLED_SERVICES);
-
-    var enabledServices = getEnabledServices(services);
+    var enabledServices = getEnabledServices(app.services);
 
     res.render('services', {
       translate: app.translate,

--- a/webgui/routes/services.js
+++ b/webgui/routes/services.js
@@ -1,14 +1,3 @@
-/* Local services should be listed and enabled in /usr/local/etc/colte/services.json. 
-  Format of JSON file should be: 
-  {
-    serviceName: {
-      enabled: boolean,
-      url: string
-    }, 
-    ...
-  }
-*/
-
 var express = require('express');
 var router = express.Router();
 var customer = require('../models/customer');
@@ -35,11 +24,6 @@ router.get('/', function(req, res, next) {
   var ip = app.generateIP(req.ip);
   console.log("Web Request From: " + ip)
   customer.find_by_ip(ip).then((data) => {
-    // console.log(data);
-
-    // raw_up_str = convertBytes(data[0].raw_up);
-    // raw_down_str = convertBytes(data[0].raw_down);
-    // data_balance_str = convertBytes(data[0].data_balance);
 
     var enabledServices = getEnabledServices(app.services);
 
@@ -48,11 +32,6 @@ router.get('/', function(req, res, next) {
       title: app.translate("Home"),
       admin: data[0].admin,
       services: enabledServices
-      // raw_up_str: raw_up_str,
-      // raw_down_str: raw_down_str,
-      // balance: data[0].balance,
-      // data_balance_str: data_balance_str,
-      // msisdn: data[0].msisdn,
     });
   });
 });

--- a/webgui/routes/status.js
+++ b/webgui/routes/status.js
@@ -22,6 +22,7 @@ router.get('/', function(req, res, next) {
       data_balance_str: data_balance_str,
       msisdn: data[0].msisdn,
       admin: data[0].admin,
+      services: app.services,
     });
   });
 });

--- a/webgui/routes/transfer.js
+++ b/webgui/routes/transfer.js
@@ -15,7 +15,8 @@ router.get('/', function(req, res, next) {
       raw_up: data[0].raw_up,
       raw_down: data[0].raw_down,
       balance: data[0].balance,
-      admin: data[0].admin
+      admin: data[0].admin,
+      services: app.services,
     });
   });
 });

--- a/webgui/views/layout.hbs
+++ b/webgui/views/layout.hbs
@@ -47,10 +47,12 @@
 	    <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/status">{{translate "Account"}}</a></li>
 	    <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/transfer">{{translate "Transfer"}}</a></li>
 	    <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/purchase">{{translate "Purchase"}}</a></li>
-<!--       {{#if admin }}
+<!--  {{#if admin }}
       <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/admin">{{translate "Admin"}}</a></li> 
+      {{/if}} -->
+      {{#if services }}
+	    <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/services">{{translate "Free Services"}}</a></li>
       {{/if}}
-	    <li class="nav-item"><a style="font-size:12px" class="nav-link" href="/services">{{translate "Free Services"}}</a></li> -->
     </ul>
     {{{body}}}
   </body>

--- a/webgui/views/services.hbs
+++ b/webgui/views/services.hbs
@@ -1,23 +1,12 @@
 <main role="main" class="container">
     <div class="card mb-3">
       <div class="card-header">
-        {{translate "Free Services"}}
-      </div>
-      <div class="card-body">
-          <p><a href="http://media.bokondini" class="btn btn-primary btn-sm">{{translate "Movies"}}</a></p>
-          <p><a href="http://wiki.bokondini" class="btn btn-primary btn-sm">Wikipedia</a></p>
-          <p><a href="http://maps.bokondini" class="btn btn-primary btn-sm">{{translate "Maps"}}</a></p>
-          <p><a href="http://chat.bokondini" class="btn btn-primary btn-sm">{{translate "Chat"}}</a></p>
-      </div>
-    </div>
-    <div class="card mb-3">
-      <div class="card-header">
         {{!-- TODO: Add translation of this term! --}}
-        {{translate "Enabled Services"}}
+        {{translate "Free Web Services"}}
       </div>
       <div class="card-body">
-          {{#each service}}
-            <p><a href={{this.url}} class="btn btn-primary btn-sm">{{translate this.serviceName}}</a></p>
+          {{#each services}}
+            <p><a href={{this.url}} class="btn btn-primary btn-sm">{{this.serviceName}}</a></p>
           {{/each}}
       </div>
     </div>

--- a/webgui/views/services.hbs
+++ b/webgui/views/services.hbs
@@ -10,4 +10,15 @@
           <p><a href="http://chat.bokondini" class="btn btn-primary btn-sm">{{translate "Chat"}}</a></p>
       </div>
     </div>
+    <div class="card mb-3">
+      <div class="card-header">
+        {{!-- TODO: Add translation of this term! --}}
+        {{translate "Enabled Services"}}
+      </div>
+      <div class="card-body">
+          {{#each service}}
+            <p><a href={{this.url}} class="btn btn-primary btn-sm">{{translate this.serviceName}}</a></p>
+          {{/each}}
+      </div>
+    </div>
 </main>


### PR DESCRIPTION
Adding ability to render currently enabled services to anyone on the network as defined in a local JSON file (`/usr/local/etc/colte/services.json`). Network admins can update this file so users can access local services.