### PR TITLE
Devel packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 GIT_VERSION=$(shell git describe --tags | sed s/-g/+g/g)
 TARGET_DIR=./BUILD
-NFPM_VERSION = "2.2.3"
+NFPM_VERSION = 2.2.3
+HOST_ARCH=$(shell uname -m)
+ifeq ($(HOST_ARCH),aarch64)
+	NPM_ARCH=arm64
+else ifeq ($(HOST_ARCH),x86_64)
+	NPM_ARCH=x86_64
+else
+	$(error Unsupported host platform arch $(HOST_ARCH))
+endif
 
 .PHONY: all get_nfpm install_apt_deps install_deps clean
 
@@ -10,7 +18,7 @@ get_nfpm: $(TARGET_DIR)/nfpm/nfpm
 
 $(TARGET_DIR)/nfpm/nfpm:
 	mkdir -p $(@D)
-	curl -L https://github.com/goreleaser/nfpm/releases/download/v$(NFPM_VERSION)/nfpm_$(NFPM_VERSION)_Linux_x86_64.tar.gz | tar -xz --directory "$(TARGET_DIR)/nfpm"
+	curl -L https://github.com/goreleaser/nfpm/releases/download/v$(NFPM_VERSION)/nfpm_$(NFPM_VERSION)_Linux_$(NPM_ARCH).tar.gz | tar -xz --directory "$(TARGET_DIR)/nfpm"
 
 install_apt_deps:
 	sudo apt-get install build-essential default-mysql-client default-mysql-server nodejs npm curl

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,211 @@
+name: "colte"
+arch: "amd64"
+platform: "linux"
+
+# Upstream Version. (required)
+# This will expand any env var you set in the field, eg version: v${SEMVER}
+version: ${VERSION}
+
+# Version Epoch.
+# Default is extracted from `version` if it is semver compatible.
+# epoch: 1
+
+# Version Prerelease.
+# Default is extracted from `version` if it is semver compatible.
+# prerelease: beta1
+
+# Version Metadata (previously deb.metadata).
+# Default is extracted from `version` if it is semver compatible.
+# Setting metadata might interfere with version comparisons depending on the packager.
+# version_metadata: "git"
+
+# Package Release Revision (Usually 1).
+# This will expand any env var you set in the field, eg release: ${VERSION_RELEASE}
+# release: 1
+
+section: "net"
+priority: "optional"
+maintainer: "Matthew Johnson <matt9j@cs.washington.edu>"
+description: "The Community LTE Project"
+vendor: "UW-ICTD <colte@cs.washington.edu>"
+homepage: "https://github.com/uw-ictd/colte"
+license: "MIT"
+
+# Changelog YAML file, see: https://github.com/goreleaser/chglog
+#changelog: "changelog.yaml"
+
+# Disables globbing for files, config_files, etc.
+disable_globbing: false
+
+# Packages it replaces. (overridable)
+replaces:
+  # - foobar
+
+# Packages it provides. (overridable)
+provides:
+  # - bar
+
+# Dependencies. (overridable)
+depends:
+  - "open5gs-hss (>= 2.0.0)"
+  - "open5gs-sgwu (>= 2.0.0)"
+  - "open5gs-sgwc (>= 2.0.0)"
+  - "open5gs-mme (>= 2.0.0)"
+  - "open5gs-pcrf (>= 2.0.0)"
+  - "open5gs-smf (>= 2.0.0)"
+  - "open5gs-upf (>= 2.0.0)"
+  - "haulage"
+  - "python3"
+  - "nodejs (>= 8.0.0)"
+  - "default-mysql-client"
+  - "default-mysql-server"
+  - "python3-netaddr"
+  - "python3-ruamel.yaml"
+  - "python3-mysqldb"
+
+# Recommended packages. (overridable)
+recommends:
+#  - fooa
+
+# Suggested packages. (overridable)
+suggests:
+#  - foob
+
+# Packages it conflicts with. (overridable)
+conflicts:
+#  - fooc
+
+# Contents to add to the package
+# This can be binaries or any other files.
+contents:
+  # Basic files that applies to all packagers
+  - src: "./package/sample_db.sql"
+    dst: "/etc/colte/sample_db.sql"
+
+  - src: "./conf/coltenat.sh"
+    dst: "/usr/bin/coltenat"
+
+  - src: "./package/colte-nat.service"
+    dst: "/etc/systemd/system/colte-nat.service"
+
+  - src: "./conf/colteconf.py"
+    dst: "/usr/bin/colteconf"
+
+  - src: "./conf/coltedb.py"
+    dst: "/usr/bin/coltedb"
+
+  - src: "./conf/open5gs_dbconf.sh"
+    dst: "/etc/colte/colte_open5gsdb"
+
+  - src: "./package/colte-webadmin.service"
+    dst: "/etc/systemd/system/colte-webadmin.service"
+
+  - src: "./package/colte-webgui.service"
+    dst: "/etc/systemd/system/colte-webgui.service"
+
+  - src: "./webadmin/*"
+    dst: "/usr/bin/colte-webadmin"
+
+  - src: "./webgui/*"
+    dst: "/usr/bin/colte-webgui"
+
+  - src: "./colte-common-models/*"
+    dst: "/usr/bin/colte-common-models"
+
+  # Installed symlinks
+  # Will result in `ln -s ${src} ${dst}`.
+  - src: /etc/haulage/config.yml
+    dst: /etc/colte/haulage.yml
+    type: "symlink"
+
+  - src: "/usr/bin/colte-webgui/pricing.json"
+    dst: "/etc/colte/pricing.json"
+    type: "symlink"
+
+  - src: "/usr/bin/colte-webadmin/.env"
+    dst: "/etc/colte/webadmin.env"
+    type: "symlink"
+
+  - src: "/usr/bin/colte-webgui/.env"
+    dst: "/etc/colte/webgui.env"
+    type: "symlink"
+
+  # Explicit symlinks for relative NPM packages
+  - src: "/usr/bin/colte-common-models"
+    dst: "/usr/bin/colte-webgui/node_modules/colte-common-models"
+    type: "symlink"
+  - src: "/usr/bin/colte-common-models"
+    dst: "/usr/bin/colte-webadmin/node_modules/colte-common-models"
+    type: "symlink"
+
+
+  # Config files
+  - src: ./conf/config.yml
+    dst: /etc/colte/config.yml
+    type: config
+
+  - src: "./webgui/.env"
+    dst: "/usr/bin/colte-webgui/.env"
+    type: "config"
+
+  - src: "./webadmin/.env"
+    dst: "/usr/bin/colte-webadmin/.env"
+    type: "config"
+
+  # Mark the transaction log as config for now to avoid overwriting existing logs.
+  # TODO(matt9j) Move the transaction log to the database.
+  - src: ./package/transactions_log.txt
+    dst: /var/log/colte/transactions_log.txt
+
+  # Sometimes it is important to be able to set the mtime, mode, owner, or group for a file
+  # that differs from what is on the local build system at build time.
+  # - src: path/to/foo
+  #   dst: /usr/local/foo
+  #   file_info:
+  #     mode: 0644
+  #     mtime: 2008-01-02T15:04:05Z
+  #     owner: notRoot
+  #     group: notRoot
+
+
+# Empty folders your package may need created. (overridable)
+empty_folders:
+  - /var/log/colte
+
+# Scripts to run at specific stages. (overridable)
+scripts:
+  # preinstall: ./scripts/preinstall.sh
+  postinstall: ./package/postinst
+  # preremove: ./scripts/preremove.sh
+  postremove: ./package/postrm
+
+# Custom configuration applied only to the Deb packager.
+deb:
+  # # Custom deb special files.
+  # scripts:
+  #   # Deb rules script.
+  #   rules: foo.sh
+  #   # Deb templates file, when using debconf.
+  #   templates: templates
+
+  # # Custom deb triggers
+  # triggers:
+  #   # register interrest on a trigger activated by another package
+  #   # (also available: interest_await, interest_noawait)
+  #   interest:
+  #     - some-trigger-name
+  #   # activate a trigger for another package
+  #   # (also available: activate_await, activate_noawait)
+  #   activate:
+  #     - another-trigger-name
+
+  # # The package is signed if a key_file is set
+  # signature:
+  #   # PGP secret key (can also be ASCII-armored). The passphrase is taken
+  #   # from the environment variable $NFPM_DEB_PASSPHRASE with a fallback
+  #   # to #NFPM_PASSPHRASE.
+  #   # This will expand any env var you set in the field, eg key_file: ${SIGNING_KEY_FILE}
+  #   key_file: key.gpg
+  #   # The type describes the signers role, possible values are "origin",
+  #   # "maint" and "archive". If unset, the type defaults to "origin".
+  #   type: origin

--- a/package/haulage.yml
+++ b/package/haulage.yml
@@ -1,1 +1,0 @@
-/etc/haulage/config.yml

--- a/package/pricing.json
+++ b/package/pricing.json
@@ -1,1 +1,0 @@
-/usr/bin/colte-webgui/pricing.json

--- a/package/webadmin.env
+++ b/package/webadmin.env
@@ -1,1 +1,0 @@
-/usr/bin/colte-webadmin/.env

--- a/package/webgui.env
+++ b/package/webgui.env
@@ -1,1 +1,0 @@
-/usr/bin/colte-webgui/.env


### PR DESCRIPTION
This commit moves from FPM for packaging to nfpm to remove the build dependency on ruby. This has the side-benefit of using a more explicit packaging config file, which should hopefully address the issues we were seeing with too many files being interpreted as configuration.