### PR TITLE
conf: Include newline in sysctl.conf edit

### DIFF
--- a/conf/colteconf.py
+++ b/conf/colteconf.py
@@ -54,7 +54,7 @@ def update_env_file(file_name, colte_data):
         file.write(new_text)
 
 def enable_ip_forward():
-    replaceAll("/etc/sysctl.conf", "net.ipv4.ip_forward", "net.ipv4.ip_forward=1", True)
+    replaceAll("/etc/sysctl.conf", "net.ipv4.ip_forward", "net.ipv4.ip_forward=1\n", True)
     os.system('sysctl -w net.ipv4.ip_forward=1')
 
 def update_colte_nat_script(colte_data):


### PR DESCRIPTION
The replaceAll command seems kind of strange in that it matches an
entire line, but then on edit does not write an entire line, only
inserting the specific expression *without a newline by default*. This
commit adds a newline to the inserted ip forward line in
sysctl.conf. Without this newline, a corrupted sysctl entry will be
created with a mix of whatever content was on the next line in the
file.