### PR TITLE
change LTE subnet addresses written to smf.conf and upf.conf

### DIFF
--- a/conf/colteconf.py
+++ b/conf/colteconf.py
@@ -241,7 +241,9 @@ def update_smf(colte_data):
         smf_data["smf"]["pfcp"].append({'addr': "127.0.0.4"})
         smf_data["smf"]["pfcp"].append({'addr': "::1"})
 
-        smf_data["smf"]["subnet"].append({'addr': colte_data["lte_subnet"]})
+        net = IPNetwork(colte_data["lte_subnet"])
+        netstr = str(net[1]) + "/" + str(net.prefixlen)
+        smf_data["smf"]["subnet"].append({'addr': netstr})
 
         smf_data["smf"]["dns"].append(colte_data["dns"])
 
@@ -292,7 +294,10 @@ def update_upf(colte_data):
 
         upf_data["upf"]["pfcp"].append({'addr': "127.0.0.7"})
         upf_data["upf"]["gtpu"].append({'addr': "127.0.0.7"})
-        upf_data["upf"]["subnet"].append({'addr': colte_data["lte_subnet"]})
+
+        net = IPNetwork(colte_data["lte_subnet"])
+        netstr = str(net[1]) + "/" + str(net.prefixlen)
+        upf_data["upf"]["subnet"].append({'addr': netstr})
 
         # Link to the SMF
         # TODO(matt9j) Might not be needed


### PR DESCRIPTION
The default values for subnet in the open5gs conf files pertaining to the LTE subnet (smf.conf and upf.conf) use the first valid address in the subnet (e.g. 10.45.0.1/16), whereas colteconf writes the subnet notation directly (e.g. 10.45.0.0/16). I am not sure if this breaks anything or not, but consistency is good.