### PR TITLE
"subnet" -> "pdn" in update_smf

### DIFF
--- a/conf/colteconf.py
+++ b/conf/colteconf.py
@@ -211,8 +211,8 @@ def update_smf(colte_data):
         if "smf" in smf_data and "pfcp" in smf_data["smf"]:
             del smf_data["smf"]["pfcp"][:]
 
-        if "smf" in smf_data and "pdn" in smf_data["smf"]:
-            del smf_data["smf"]["pdn"][:]
+        if "smf" in smf_data and "subnet" in smf_data["smf"]:
+            del smf_data["smf"]["subnet"][:]
 
         if "smf" in smf_data and "dns" in smf_data["smf"]:
             del smf_data["smf"]["dns"][:]


### PR DESCRIPTION
We previously changed "subnet" to "pdn" in smf and upf conf files due to schema changing, but one instance of "pdn" still exists in update_smf. As currently written, every time we call colteconf update it just adds a value to the subnet field instead of clearing out the old values.