### PR TITLE
python: Remove coltedb dependency on psycopg2

### DIFF
--- a/python/coltedb.py
+++ b/python/coltedb.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 
-import psycopg2
 import ruamel.yaml
 
 log = logging.getLogger(__name__)
@@ -82,10 +81,6 @@ if __name__ == "__main__":
     dbname = colte_data["mysql_db"]
     db_user = colte_data["mysql_user"]
     db_pass = colte_data["mysql_password"]
-    db = psycopg2.connect(
-        host="localhost", user=db_user, password=db_pass, dbname=dbname
-    )
-    cursor = db.cursor()
 
     if command == "add":
         if (len(sys.argv) > 9) or (len(sys.argv) < 7):
@@ -96,7 +91,9 @@ if __name__ == "__main__":
         elif len(sys.argv) == 9:
             if accounting is not None:
                 accounting.add_user(
-                    cursor=cursor,
+                    db_name=dbname,
+                    db_user=db_user,
+                    db_pass=db_pass,
                     imsi=sys.argv[2],
                     msisdn=sys.argv[3],
                     ip=sys.argv[4],
@@ -113,7 +110,9 @@ if __name__ == "__main__":
         elif len(sys.argv) == 8:
             if accounting is not None:
                 accounting.add_user(
-                    cursor=cursor,
+                    db_name=dbname,
+                    db_user=db_user,
+                    db_pass=db_pass,
                     imsi=sys.argv[2],
                     msisdn=sys.argv[3],
                     ip=sys.argv[4],
@@ -130,7 +129,9 @@ if __name__ == "__main__":
         else:
             if accounting is not None:
                 accounting.add_user(
-                    cursor=cursor,
+                    db_name=dbname,
+                    db_user=db_user,
+                    db_pass=db_pass,
                     imsi=sys.argv[2],
                     msisdn=sys.argv[3],
                     ip=sys.argv[4],
@@ -151,7 +152,9 @@ if __name__ == "__main__":
                 'coltedb: incorrect number of args, format is "coltedb remove imsi"'
             )
         if accounting is not None:
-            accounting.remove_user(cursor=cursor, imsi=sys.argv[2])
+            accounting.remove_user(
+                db_name=dbname, db_user=db_user, db_pass=db_pass, imsi=sys.argv[2]
+            )
         if core_network is not None:
             core_network.remove_user(imsi=sys.argv[2])
 
@@ -164,7 +167,13 @@ if __name__ == "__main__":
             raise NotImplementedError(
                 "topup has no effect with no installed accounting module"
             )
-        accounting.topup(cursor=cursor, imsi=sys.argv[2], amount=sys.argv[3])
+        accounting.topup(
+            db_name=dbname,
+            db_user=db_user,
+            db_pass=db_pass,
+            imsi=sys.argv[2],
+            amount=sys.argv[3],
+        )
 
     elif command == "topup_data":
         if len(sys.argv) != 4:
@@ -186,7 +195,9 @@ if __name__ == "__main__":
             raise NotImplementedError(
                 "admin has no effect with no installed accounting module"
             )
-        accounting.set_admin(cursor=cursor, imsi=sys.argv[2])
+        accounting.set_admin(
+            db_name=dbname, db_user=db_user, db_pass=db_pass, imsi=sys.argv[2]
+        )
 
     elif command == "noadmin":
         if len(sys.argv) != 3:
@@ -197,11 +208,9 @@ if __name__ == "__main__":
             raise NotImplementedError(
                 "noadmin has no effect with no installed accounting module"
             )
-        accounting.unset_admin(cursor=cursor, imsi=sys.argv[2])
+        accounting.unset_admin(
+            db_name=dbname, db_user=db_user, db_pass=db_pass, imsi=sys.argv[2]
+        )
 
     else:
         display_help()
-
-    db.commit()
-    cursor.close()
-    db.close()

--- a/python/coltedb_prepaid.py
+++ b/python/coltedb_prepaid.py
@@ -7,7 +7,12 @@ import psycopg2
 log = logging.getLogger(__name__)
 
 
-def add_user(cursor, imsi, msisdn, ip, currency):
+def add_user(db_name, db_user, db_pass, imsi, msisdn, ip, currency):
+    db = psycopg2.connect(
+        host="localhost", user=db_user, password=db_pass, dbname=db_name
+    )
+    cursor = db.cursor()
+
     # TODO: error-handling? Check if imsi/msisdn/ip already in system?
     log.info("coltedb: adding user %s", str(imsi))
     try:
@@ -39,8 +44,17 @@ def add_user(cursor, imsi, msisdn, ip, currency):
 
     subprocess.run(["haulagedb", "add", str(imsi), str(ip)], check=True)
 
+    db.commit()
+    cursor.close()
+    db.close()
 
-def remove_user(cursor, imsi):
+
+def remove_user(db_name, db_user, db_pass, imsi):
+    db = psycopg2.connect(
+        host="localhost", user=db_user, password=db_pass, dbname=db_name
+    )
+    cursor = db.cursor()
+
     try:
         cursor.execute("BEGIN TRANSACTION")
 
@@ -57,8 +71,17 @@ def remove_user(cursor, imsi):
 
     subprocess.run(["haulagedb", "remove", str(imsi)], check=True)
 
+    db.commit()
+    cursor.close()
+    db.close()
 
-def topup(cursor, imsi, amount):
+
+def topup(db_name, db_user, db_pass, imsi, amount):
+    db = psycopg2.connect(
+        host="localhost", user=db_user, password=db_pass, dbname=db_name
+    )
+    cursor = db.cursor()
+
     old_balance = 0
     new_balance = 0
 
@@ -104,22 +127,41 @@ def topup(cursor, imsi, amount):
         if answer == "n" or answer == "N":
             log.info("coltedb: cancelling topup\n")
             break
+    db.commit()
+    cursor.close()
+    db.close()
 
 
 def topup_data(imsi, amount):
     subprocess.run(["haulagedb", "topup", str(imsi), str(amount)], check=True)
 
 
-def set_admin(cursor, imsi):
+def set_admin(db_name, db_user, db_pass, imsi):
+    db = psycopg2.connect(
+        host="localhost", user=db_user, password=db_pass, dbname=db_name
+    )
+    cursor = db.cursor()
+
     log.info("coltedb: giving admin privileges to user %s", str(imsi))
     commit_str = "UPDATE customers SET admin = true WHERE imsi = '" + imsi + "'"
     cursor.execute(commit_str)
+    db.commit()
+    cursor.close()
+    db.close()
 
 
-def unset_admin(cursor, imsi):
+def unset_admin(db_name, db_user, db_pass, imsi):
+    db = psycopg2.connect(
+        host="localhost", user=db_user, password=db_pass, dbname=db_name
+    )
+    cursor = db.cursor()
+
     log.info("coltedb: removing admin privileges from user %s", str(imsi))
     commit_str = "UPDATE customers SET admin = false WHERE imsi = '" + imsi + "'"
     cursor.execute(commit_str)
+    db.commit()
+    cursor.close()
+    db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
psycopg2 is only needed when communicating with postgres, which should
only be required when using the metering functionality. The base
install should not require a database connection. Before this commit
the base coltedb wrapper was creating a database connection and then
passing it into the different implementation functions. This meant the
database connection library was required, even if the connection was
never needed. This commit moves the connection creation into each
prepaid billing function.

This does result in a lot of duplication, and in-general the
organization of the coltedb base script and the specialization scripts
could be improved a lot.