### PR TITLE
webadmin: Disable popover content sanitization

### DIFF
--- a/webadmin/public/javascripts/admin.js
+++ b/webadmin/public/javascripts/admin.js
@@ -42,7 +42,7 @@
 })();
 
 $(document).ready(function () {
-  $('[data-toggle="popover"]').popover();
+  $('[data-toggle="popover"]').popover({sanitize: false});
 
   $(function () {
     $('[data-toggle="popover"]').popover({


### PR DESCRIPTION
We're currently using popovers for the edit box, which in the current
implementation includes inline javascript which is rejected by the
bootstrap sanitizer. This has been broken since the upgrade to
bootstrap 4.5.3 in commit
2db4670a849a6ea560b93e73d3d84792b5eb66cd. This commit addresses the
shorterm issue by disabling popover data sanitization, but in the long
term it would be better to have a clearer and more sandboxed way to edit
information in the page.

Resolves #115 