### PR TITLE
fixed build issues and updated readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ build_common_models:
 	cd colte-common-models; npm ci
 
 build_webgui: build_common_models
-	cd webgui; npm ci
+	cd webgui; rm -rf node_modules; rm package-lock.json; npm i; npm ci
 
 build_webadmin: build_common_models
-	cd webadmin; npm ci
+	cd webadmin; rm -rf node_modules; rm package-lock.json; npm i; npm ci
 
 build_arm64 build_x86_64: build_webgui build_webadmin
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ npm start
 
 After installation, pointers to all the various config files can be found in `/etc/colte/`. The main config file is `config.yml`. After you edit this file, run `colteconf` to reconfigure all components and restart them as necessary. Note that you **must** run colteconf at least once after installing CoLTE, because there is no way for us to know some of the options (e.g. upstream and downstream interfaces).
 
+*Note: In the current state of this repo, running colteconf will give you apython type error. We are working on a fix, but for now, delete the spaces and hyphens in `/etc/open5gs/mme.yaml` so the `gummei` and `tai` sections look as they do below:*
+
+```
+  gummei:
+    plmn_id:
+      mcc: 910
+      mnc: 54
+    mme_gid: 2
+    mme_code: 1
+  tai:
+    plmn_id:
+      mcc: 910
+      mnc: 54
+    tac: 1
+```
+
 ## Basic Configs:
 
 Conceptually, your machine will need two network connections: one to the Internet (the upstream WAN) and another to the eNodeB (the downstream LAN) - these can actually be the same interface, it doesn't matter.


### PR DESCRIPTION
Currently, trying to build from source by running `sudo make` gives the user some npm erros. This was due to outdated `package-lock.json` files and `node_modules` folders. This PR edits the makefile so we generate a new clean package-lock and node_modules on each build. 

After successfully building and installing, running `sudo colteconf update` causes a python type error because, while we recently merged a PR to fix `colteconf_cn_4g.py` it still cannot parse `/etc/open5gs/mme.yaml` out of the box for version 2.7.0. Until we fix the parsing, our readme should warn users about this.